### PR TITLE
Move requirements to setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-redis
-aioredis
-msgpack-python
-git+https://github.com/facebook/pyre2.git

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='browscap-python',
-    version='0.0.14',
+    version='0.0.15',
     description='Python Browscap Library.',
     url='https://github.com/kvspb/browscap-python',
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,15 @@ setup(
     platforms=['any'],
 
     packages=find_packages(),
+    install_requires=[
+        'aioredis',
+        'fb-re2',
+        'msgpack-python',
+        'redis',
+    ],
+    dependency_links=[
+        'git+https://github.com/facebook/pyre2.git#egg=fb-re2',
+    ],
 
     classifiers=[
         #   3 - Alpha

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,6 @@ setup(
         'msgpack-python',
         'redis',
     ],
-    dependency_links=[
-        'git+https://github.com/facebook/pyre2.git@master#egg=fb-re2',
-    ],
-
     classifiers=[
         #   3 - Alpha
         #   4 - Beta

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='browscap-python',
-    version='0.0.15',
+    version='0.0.16',
     description='Python Browscap Library.',
     url='https://github.com/kvspb/browscap-python',
 
@@ -20,7 +20,7 @@ setup(
         'redis',
     ],
     dependency_links=[
-        'git+https://github.com/facebook/pyre2.git#egg=fb-re2',
+        'git+https://github.com/facebook/pyre2.git@master#egg=fb-re2',
     ],
 
     classifiers=[


### PR DESCRIPTION
This pull-request adds automatic requirements installation on package installation with pip.
For local development instead of `pip instal -r requirements.txt` you can do `pip install -e .`. It is good practice for distributed packages.